### PR TITLE
Add API client to the Plugin context

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,0 +1,10 @@
+from slackclient import SlackClient
+import json
+
+api_client = None
+
+
+def init(token):
+    global api_client
+    api_client = SlackClient(token)
+    return api_client

--- a/client.py
+++ b/client.py
@@ -1,18 +1,23 @@
 from slackclient import SlackClient
 import json
 
+# instance of API client that can be accessed from other files
 api_client = None
 
 
+# create an instance of the api client and initialize it with a token
 def init(token):
     global api_client
     api_client = SlackClient(token)
     return api_client
 
 
+# example functions
+
+# get_users() returns a list of users in a Slack organization
 def get_users():
     return json.loads(api_client.api_call('users.list'))['members']
 
-
+# get_presence returns if a certain user is active or not in chat
 def get_presence(id):
     return json.loads(api_client.api_call('users.getPresence', user=id))

--- a/client.py
+++ b/client.py
@@ -8,3 +8,11 @@ def init(token):
     global api_client
     api_client = SlackClient(token)
     return api_client
+
+
+def get_users():
+    return json.loads(api_client.api_call('users.list'))['members']
+
+
+def get_presence(id):
+    return json.loads(api_client.api_call('users.getPresence', user=id))

--- a/doc/example-plugins/print_active_users.py
+++ b/doc/example-plugins/print_active_users.py
@@ -1,0 +1,24 @@
+import client
+
+outputs = []
+
+# prints all users who are currently active in the channel
+def print_active_users():
+    #NOTE: you must add a real channel ID for this to work
+    active_users = get_active_users()
+    outputs.append([u"XXXXXXXXX", active_users])
+
+# calls the API to get all the users
+# then checks the status of each user
+# returns a list of the active users joined by spaces
+def get_active_users():
+    users = client.get_users()
+    present_users = []
+    # print all_users
+    for user in users:
+        presence = client.get_presence(user['id'])
+        if presence['presence'] == 'active':
+            present_users.append(user['real_name'])
+    return u', '.join(present_users)
+
+print_active_users()

--- a/rtmbot.py
+++ b/rtmbot.py
@@ -11,22 +11,20 @@ import sys
 import time
 import logging
 from argparse import ArgumentParser
-
-from slackclient import SlackClient
+import client
 
 def dbg(debug_string):
     if debug:
         logging.info(debug_string)
 
 class RtmBot(object):
-    def __init__(self, token):
+    def __init__(self, slackclient):
         self.last_ping = 0
-        self.token = token
+        self.token = slackclient.token
         self.bot_plugins = []
-        self.slack_client = None
+        self.slack_client = slackclient
     def connect(self):
         """Convenience method that creates Server instance"""
-        self.slack_client = SlackClient(self.token)
         self.slack_client.rtm_connect()
     def start(self):
         self.connect()
@@ -187,7 +185,8 @@ if __name__ == "__main__":
 
     config = yaml.load(file(args.config or 'rtmbot.conf', 'r'))
     debug = config["DEBUG"]
-    bot = RtmBot(config["SLACK_TOKEN"])
+    api_client = client.init(config["SLACK_TOKEN"]
+    bot = RtmBot(api_client)
     site_plugins = []
     files_currently_downloading = []
     job_hash = {}

--- a/rtmbot.py
+++ b/rtmbot.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
 
     config = yaml.load(file(args.config or 'rtmbot.conf', 'r'))
     debug = config["DEBUG"]
-    api_client = client.init(config["SLACK_TOKEN"]
+    api_client = client.init(config["SLACK_TOKEN"])
     bot = RtmBot(api_client)
     site_plugins = []
     files_currently_downloading = []


### PR DESCRIPTION
Add an API client object that can be accessed by importing the client.py file and using the api_client object. This api_client object is an instance of a SlackClient that can make API method calls. This allows a user to make Slack API calls while using the RTM bot functionality. 

An example is included in doc/example-plugins/print_active_users.py that on loading the bot, will print the active users in the chat by using the Slack API to get all users in the organization and then checking each users presence in the chat.
