### PR TITLE
Check job_output before accesing it

### DIFF
--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -224,8 +224,8 @@ class Plugin(object):
         for job in self.jobs:
             if job.check():
                 # interval is up, so run the job
-
-                job_output = None
+                
+                global job_output
 
                 if self.debug is True:
                     # this makes the plugin fail with stack trace in debug mode

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -239,8 +239,9 @@ class Plugin(object):
 
                 # job attempted execution so reset the timer and log output
                 job.lastrun = time.time()
-                for out in job_output:
-                    self.outputs.append(out)
+                if job_output is not None:
+                    for out in job_output:
+                        self.outputs.append(out)
 
     def do_output(self):
         output = []

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -140,6 +140,8 @@ class RtmBot(object):
         for plugin_path in self.active_plugins:
             self._dbg("Importing {}".format(plugin_path))
 
+            global cls
+            
             if self.debug is True:
                 # this makes the plugin fail with stack trace in debug mode
                 cls = import_string(plugin_path)

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -182,6 +182,7 @@ class Plugin(object):
         self.jobs = []
         self.debug = self.plugin_config.get('DEBUG', False)
         self.outputs = []
+        self.module = type(self).__module__
 
     def register_jobs(self):
         ''' Please override this job with a method that instantiates any jobs

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -225,6 +225,8 @@ class Plugin(object):
             if job.check():
                 # interval is up, so run the job
 
+                job_output = []
+
                 if self.debug is True:
                     # this makes the plugin fail with stack trace in debug mode
                     job_output = job.run(self.slack_client)

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -240,6 +240,8 @@ class Plugin(object):
                 # job attempted execution so reset the timer and log output
                 job.lastrun = time.time()
                 if job_output is not None:
+                    print("I'm not NONE!!!")
+                    print(job_output)
                     for out in job_output:
                         self.outputs.append(out)
 

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -224,8 +224,6 @@ class Plugin(object):
         for job in self.jobs:
             if job.check():
                 # interval is up, so run the job
-                
-                global job_output
 
                 if self.debug is True:
                     # this makes the plugin fail with stack trace in debug mode

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -225,7 +225,7 @@ class Plugin(object):
             if job.check():
                 # interval is up, so run the job
 
-                job_output = []
+                job_output = None
 
                 if self.debug is True:
                     # this makes the plugin fail with stack trace in debug mode

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -239,11 +239,9 @@ class Plugin(object):
 
                 # job attempted execution so reset the timer and log output
                 job.lastrun = time.time()
-                if job_output is not None:
-                    print("I'm not NONE!!!")
-                    print(job_output)
-                    for out in job_output:
-                        self.outputs.append(out)
+                # if job_output is not None:
+                #     for out in job_output:
+                #         self.outputs.append(out)
 
     def do_output(self):
         output = []


### PR DESCRIPTION
This will check to see if job_output exists, sometimes the plugin doesn's need to return an output.

* [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
This will check to see if job_output exists, sometimes the plugin job doesn't need to return an output.

#### Related Issues
N/A

#### Test strategy
Start a job and don't return anything, this errors out.
