### PR TITLE
Fix to job_output bug

### DIFF
--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -221,6 +221,7 @@ class Plugin(object):
                     )
 
     def do_jobs(self):
+        job_output = []
         for job in self.jobs:
             if job.check():
                 # interval is up, so run the job
@@ -239,8 +240,9 @@ class Plugin(object):
 
                 # job attempted execution so reset the timer and log output
                 job.lastrun = time.time()
-                for out in job_output:
-                    self.outputs.append(out)
+                if job_output:
+                    for out in job_output:
+                        self.outputs.append(out)
 
     def do_output(self):
         output = []


### PR DESCRIPTION
Resolves error where rtmbot crashes due to no job_output

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> e.g. New functionality for producing whatsits.

#### Related Issues
> e.g. Fixes #206 and closes #230

#### Test strategy
> e.g. Add tests around whatsit production.
